### PR TITLE
Yaml stdin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,41 +1,47 @@
-Change Log
-==========
+# Change Log
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning].
 
-[Unreleased]
-------------
+## [Unreleased]
 
-[0.2.0] -- 2017-04-21
----------------------
+## [0.3.0] -- 2018-04-12
 
 ### Fixed
 
--   `--html` was backwards; text was HTML and HTML was text [issue 4].
+* Help for `--json-data` was missing placeholder (`JSON-FILE`).
 
 ### Added
 
--   `shellquote` function to escape a string for a POSIX shell [issue 3].
+* [Sprig](http://masterminds.github.io/sprig/) functions!
 
-[0.1.0] -- 2017-04-20
----------------------
+## [0.2.0] -- 2017-04-21
+
+### Fixed
+
+* `--html` was backwards; text was HTML and HTML was text [issue 4].
 
 ### Added
 
--   Initial code. I'm still exploring how this should work and this is just the start.
--   Added README, CONTRIBUTING, and other files suggested by [flint].
--   Lots of administrative work; like figuring out testing and CI.
+* `shellquote` function to escape a string for a POSIX shell [issue 3].
 
-Thanks to
----------
+## [0.1.0] -- 2017-04-20
 
--   [keepachangelog.com]
+### Added
 
-  [Semantic Versioning]: http://semver.org/
-  [Unreleased]: https://github.com/docwhat/temple/compare/v0.2.0...HEAD
-  [0.2.0]: https://github.com/docwhat/temple/compare/v0.1.0...v0.2.0
-  [issue 4]: https://github.com/docwhat/temple/issues/4
-  [issue 3]: https://github.com/docwhat/temple/issues/3
-  [0.1.0]: https://github.com/docwhat/temple/commits/v0.1.0
-  [flint]: https://github.com/pengwynn/flint
-  [keepachangelog.com]: http://keepachangelog.com/
+* Initial code. I'm still exploring how this should work and this is just the start.
+* Added README, CONTRIBUTING, and other files suggested by [flint].
+* Lots of administrative work; like figuring out testing and CI.
+
+## Thanks to
+
+* [keepachangelog.com]
+
+[semantic versioning]: http://semver.org/
+[unreleased]: https://github.com/docwhat/temple/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/docwhat/temple/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/docwhat/temple/compare/v0.1.0...v0.2.0
+[issue 4]: https://github.com/docwhat/temple/issues/4
+[issue 3]: https://github.com/docwhat/temple/issues/3
+[0.1.0]: https://github.com/docwhat/temple/commits/v0.1.0
+[flint]: https://github.com/pengwynn/flint
+[keepachangelog.com]: http://keepachangelog.com/

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 // Config stores the configuration from cli flags and environment variables.
 type appConfig struct {
 	TemplateFile string
-	JSONDataFile string
+	DataFile     string
 	UseHTML      bool
 }
 
@@ -24,11 +24,11 @@ func main() {
 	kingpin.Version(version)
 
 	kingpin.
-		Flag("json-data", "A JSON file to use via the {{json.<foo>}} interface (Env: TEMPLE_JSON_DATA_FILE)").
-		Short('j').
-		PlaceHolder("JSON-FILE").
-		OverrideDefaultFromEnvar("TEMPLE_JSON_DATA_FILE").
-		ExistingFileVar(&config.JSONDataFile)
+		Flag("data", "A YAML or JSON file to use via the {{data.<foo>}} interface (Env: TEMPLE_DATA_FILE)").
+		Short('d').
+		PlaceHolder("DATA-FILE").
+		OverrideDefaultFromEnvar("TEMPLE_DATA_FILE").
+		ExistingFileVar(&config.DataFile)
 
 	kingpin.
 		Flag("html", "Use HTML templating instead of text templating (Env: TEMPLE_HTML)").
@@ -49,7 +49,7 @@ func main() {
 
 	kingpin.Parse()
 
-	funcMap := buildFuncMap(config.JSONDataFile)
+	funcMap := buildFuncMap(config.DataFile)
 	if config.UseHTML {
 		doHTMLTemplate(config.TemplateFile, funcMap, os.Stdout)
 	} else {

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "config:base"
+  ]
+}


### PR DESCRIPTION
Made a couple changes. They are technically backwards incompatible (for example, json to yaml keeps type information and parameter change) so I can understand not wanting them in this form but it is a rather simple PR so consider it more for inspiration?

-  defaults to stdin if filename is empty
-  switched parser to a yaml parser instead of json
-  changed the parameters + env vars to match the more general parser change

I did not update your testing script or add any tests (running on windows and haven't taken the time to do it.